### PR TITLE
Update 0001-Add-nanopc-nas-rk3588-board.patch

### DIFF
--- a/recipes-bsp/u-boot/files/0001-Add-nanopc-nas-rk3588-board.patch
+++ b/recipes-bsp/u-boot/files/0001-Add-nanopc-nas-rk3588-board.patch
@@ -35,17 +35,17 @@ index 39049ab35a9..2f1a4e37ce4 100644
 +	help
 +	  The CM3588 NAS is a Rockchip RK3588 based SBC by FriendlyElec.
 +
- config TARGET_RK3588_NEU6
- 	bool "Edgeble Neural Compute Module 6(Neu6) SoM"
+ config TARGET_NOVA_RK3588
+ 	bool "Indiedroid Nova RK3588"
  	select BOARD_LATE_INIT
-@@ -223,6 +229,7 @@ config TEXT_BASE
+@@ -232,6 +238,7 @@ config TEXT_BASE
  
  source "board/edgeble/neural-compute-module-6/Kconfig"
  source "board/friendlyelec/nanopc-t6-rk3588/Kconfig"
 +source "board/friendlyelec/nanopc-nas-rk3588/Kconfig"
+ source "board/indiedroid/nova/Kconfig"
  source "board/pine64/quartzpro64-rk3588/Kconfig"
  source "board/turing/turing-rk1-rk3588/Kconfig"
- source "board/radxa/rock5a-rk3588s/Kconfig"
 diff --git a/board/friendlyelec/nanopc-nas-rk3588/Kconfig b/board/friendlyelec/nanopc-nas-rk3588/Kconfig
 new file mode 100644
 index 00000000000..243fca95cd4
@@ -191,8 +191,8 @@ index d8e67821365..e7579a500f0 100644
       - FriendlyElec NanoPC-T6 (nanopc-t6-rk3588)
 +     - FriendlyElec CM3588 NAS (nanopc-nas-rk3588)
       - Generic RK3588S/RK3588 (generic-rk3588)
+      - Indiedroid Nova (nova-rk3588s)
       - Pine64 QuartzPro64 (quartzpro64-rk3588)
-      - Radxa ROCK 5A (rock5a-rk3588s)
 diff --git a/dts/upstream/Bindings/arm/rockchip.yaml b/dts/upstream/Bindings/arm/rockchip.yaml
 index 5cf5cbef2cf..b67bede6e49 100644
 --- a/dts/upstream/Bindings/arm/rockchip.yaml


### PR DESCRIPTION
When running build with layers recommended in README.md:
```
BBLAYERS ?= " \
  ${TOPDIR}/../meta-cm3588-nas \
  ${TOPDIR}/../meta-arm/meta-arm \
  ${TOPDIR}/../meta-arm/meta-arm-toolchain \
  ${TOPDIR}/../poky/meta \
  ${TOPDIR}/../poky/meta-poky \
  ${TOPDIR}/../poky/meta-yocto-bsp \
  ${TOPDIR}/../meta-openembedded/meta-oe \
  "
```
the build would crash with the following error:
```
ERROR: u-boot-1_2024.01-r0 do_patch: Applying patch '0001-Add-nanopc-nas-rk3588-board.patch' on target directory '/home/kubo/cm3588/yocto/build/tmp/work/nanopc_nas-poky-linux/u-boot/2024.01/git'
CmdError('quilt --quiltrc /home/kubo/cm3588/yocto/build/tmp/work/nanopc_nas-poky-linux/u-boot/2024.01/recipe-sysroot-native/etc/quiltrc push', 0, 'stdout: Applying patch 0001-Add-nanopc-nas-rk3588-board.patch
patching file arch/arm/mach-rockchip/rk3588/Kconfig
Hunk #1 succeeded at 87 with fuzz 2 (offset 9 lines).
Hunk #2 FAILED at 229.
1 out of 2 hunks FAILED -- rejects in file arch/arm/mach-rockchip/rk3588/Kconfig
patching file board/friendlyelec/nanopc-nas-rk3588/Kconfig
patching file board/friendlyelec/nanopc-nas-rk3588/MAINTAINERS
patching file configs/nanopc-nas-rk3588_defconfig
patching file doc/board/rockchip/rockchip.rst
Hunk #1 succeeded at 129 with fuzz 2.
patching file dts/upstream/Bindings/arm/rockchip.yaml
patching file dts/upstream/src/arm64/rockchip/rk3588-nanopc-nas.dts
patching file include/configs/nanopc-nas-rk3588.h
Patch 0001-Add-nanopc-nas-rk3588-board.patch does not apply (enforce with -f)

stderr: ')
ERROR: Logfile of failure stored in: /home/kubo/cm3588/yocto/build/tmp/work/nanopc_nas-poky-linux/u-boot/2024.01/temp/log.do_patch.427896
ERROR: Task (/home/kubo/cm3588/yocto/build/../poky/meta/recipes-bsp/u-boot/u-boot_2024.01.bb:do_patch) failed with exit code '1'
NOTE: Tasks Summary: Attempted 2784 tasks of which 2778 didn't need to be rerun and 1 failed.

Summary: 1 task failed:
  /home/kubo/cm3588/yocto/build/../poky/meta/recipes-bsp/u-boot/u-boot_2024.01.bb:do_patch
Summary: There was 1 ERROR message, returning a non-zero exit code.
```
I believe it was due to the 0001-Add-nanopc-nas-rk3588-board.patch referencing older versions of the files in u-boot repository. After updating the patch everything seems to be working for me, although a cross check would be much appreciated.